### PR TITLE
fix: cambiar la URL del repositorio de configuración

### DIFF
--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
     config:
       server:
         git:
-          uri: https://github.com/ddaf45/config-repo-spring-cloud.git # ¡CAMBIA ESTA URL POR LA TUYA!
+          uri: https://github.com/ddaf45/AA4-microservicios.git
+ # ¡CAMBIA ESTA URL POR LA TUYA!
           # username: tu_usuario_git
           # password: tu_token_personal_de_acceso_git


### PR DESCRIPTION
Actualizo la ruta del repositorio en el Config Server para que apunte al repositorio correcto: https://github.com/ddaf45/AA4-microservicios.git